### PR TITLE
Prevent the error "Empty or null pattern" being logged at startup.

### DIFF
--- a/src/main/java/uk/gov/hmpo/dropwizard/smartLogging/json/JsonEncoder.java
+++ b/src/main/java/uk/gov/hmpo/dropwizard/smartLogging/json/JsonEncoder.java
@@ -1,8 +1,8 @@
 package uk.gov.hmpo.dropwizard.smartLogging.json;
 
-import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.ThrowableProxy;
+import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -18,7 +18,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-public class JsonEncoder extends PatternLayoutEncoder {
+public class JsonEncoder extends LayoutWrappingEncoder<ILoggingEvent> {
 
     private static final byte[] RETURN_BYTES = "\n".getBytes();
 


### PR DESCRIPTION
Extend LayoutWrappingEncoder rather than PatternLayoutEncoder for the JsonEncoder, to prevent the error "Empty or null pattern" being logged at startup.

Note that the error did not appear in the output of **this** logger, but in the console output at startup - because the error was during startup of this logger.
