### PR TITLE
Support log messages using placeholder syntax

### DIFF
--- a/src/main/java/uk/gov/hmpo/dropwizard/smartLogging/json/JsonEncoder.java
+++ b/src/main/java/uk/gov/hmpo/dropwizard/smartLogging/json/JsonEncoder.java
@@ -34,7 +34,7 @@ public class JsonEncoder extends LayoutWrappingEncoder<ILoggingEvent> {
 
     @Override
     public void doEncode(ILoggingEvent event) throws IOException {
-        outputStream.write(convertToBytes(event, event.getMessage()));
+        outputStream.write(convertToBytes(event, event.getFormattedMessage()));
         outputStream.write(RETURN_BYTES);
         outputStream.flush();
     }

--- a/src/test/java/uk/gov/hmpo/dropwizard/smartLogging/json/JsonEncoderTest.java
+++ b/src/test/java/uk/gov/hmpo/dropwizard/smartLogging/json/JsonEncoderTest.java
@@ -46,6 +46,7 @@ public class JsonEncoderTest {
         Mockito.doReturn("LoggerName").when(event).getLoggerName();
         Mockito.doReturn("ThreadName").when(event).getThreadName();
         Mockito.doReturn("Message").when(event).getMessage();
+        Mockito.doReturn("Message").when(event).getFormattedMessage();
         Mockito.doReturn(new ThrowableProxy(new RuntimeException("Boom!"))).when(event).getThrowableProxy();
         Mockito.doReturn(new HashMap<String, String>() {
             {
@@ -78,4 +79,24 @@ public class JsonEncoderTest {
 
         DateTimeUtils.setCurrentMillisSystem();
     }
+
+    @Test
+    public void testMessageWithPlaceholderSyntax() throws Exception {
+        OutputStream os = new ByteArrayOutputStream();
+
+        JsonEncoder encoder = new JsonEncoder("host", "appname", "appenvironment", "apptype", "appsecurityzone");
+        encoder.init(os);
+
+        ILoggingEvent event = Mockito.mock(ILoggingEvent.class);
+        Mockito.doReturn(ch.qos.logback.classic.Level.ERROR).when(event).getLevel();
+        Mockito.doReturn("Message with {}").when(event).getMessage();
+        Mockito.doReturn("Message with Placeholder").when(event).getFormattedMessage();
+
+        encoder.doEncode(event);
+
+        JsonNode node = om.readTree(os.toString());
+
+        Assert.assertEquals(node.findValue("message_obj").findValue("log").asText(), "Message with Placeholder");
+    }
+
 }


### PR DESCRIPTION
Allow for log messages using the {} placeholder syntax.
Reference https://www.slf4j.org/manual.html#typical_usage